### PR TITLE
Ändere Link zu Raw-Link

### DIFF
--- a/raw.txt
+++ b/raw.txt
@@ -1,1 +1,1 @@
-https://github.com/elena1113/MetadatenDMT/blob/main/Eignungspruefung.json
+https://raw.githubusercontent.com/elena1113/MetadatenDMT/main/Eignungspruefung.json


### PR DESCRIPTION
Der bisherige Link war nicht auf die Raw-Version der Datei,
ich habe das angepasst.
Der Link auf die raw-Version findet sich rechts über dem Code.