### PR TITLE
AMB context URI Update

### DIFF
--- a/Eignungspruefung.json
+++ b/Eignungspruefung.json
@@ -1,6 +1,6 @@
 {
     "@context": [
-        "https://w3id.org/kim/amb/draft/context.jsonld",
+        "https://w3id.org/kim/amb/context.jsonld",
         {"@language": "de"}
     ],
     "id": "https://detmoldmusictools.de/index.php?cmd=courseManager&mod=course&action=show&courseId=362",


### PR DESCRIPTION
The context URI in amb was changed from `https://w3id.org/kim/amb/draft/context.jsonld` to `https://w3id.org/kim/amb/context.jsonld`

see also

* https://github.com/dini-ag-kim/amb/issues/167
* https://gitlab.com/oersi/oersi-schema/-/issues/3